### PR TITLE
Fix keyword loader path handling and clean docstring

### DIFF
--- a/backend/app/utils/risk_classifier.py
+++ b/backend/app/utils/risk_classifier.py
@@ -22,8 +22,7 @@ def _load_keywords() -> Dict[str, List[str]]:
     global _KEYWORDS_CACHE
     if _KEYWORDS_CACHE is not None:
         return _KEYWORDS_CACHE
-
-        default_path = Path(__file__).resolve().parent / "config" / "risk_keywords.yaml"
+    default_path = Path(__file__).resolve().parent / "config" / "risk_keywords.yaml"
     keywords_file = os.getenv("RISK_KEYWORDS_FILE", str(default_path))
     data: Dict[str, List[str]] = {}
     if yaml is not None and os.path.exists(keywords_file):
@@ -58,7 +57,6 @@ def classify_text(text: str) -> Tuple[str, List[str]]:
 def classify_risk(text: str) -> Tuple[str, List[str]]:
     """
     Alias for classify_text to maintain backward compatibility.
-backend/app/utils/parquet_logger.py
     """
     return classify_text(text)
 


### PR DESCRIPTION
## Summary
- ensure `_load_keywords` defines `default_path` before use so cache miss works
- remove stray docstring line from `classify_risk`

## Testing
- `python -m py_compile backend/app/utils/risk_classifier.py`
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e43260cd0832697f09402872959e9