### PR TITLE
Map backend container to port 8000

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -14,14 +14,14 @@ services:
     environment:
       DATABASE_URL: postgres://guardpilot:guardpilot@postgres:5432/guardpilot
     ports:
-      - "8080:8080"
+      - "8080:8000"
     depends_on:
       - postgres
 
   ui:
     build: ../ui
     environment:
-      BACKEND_URL: http://backend:8080
+      BACKEND_URL: http://backend:8000
     ports:
       - "8501:8501"
     depends_on:


### PR DESCRIPTION
## Summary
- map backend service to container port 8000
- update UI backend URL to match new port

## Testing
- `docker-compose -f infra/docker-compose.yml config`

------
https://chatgpt.com/codex/tasks/task_e_688e4326e4ec8326977dc22f8d4525c7