### PR TITLE
Add FastAPI tests and fix risk classifier

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+# Initializes app package for imports in tests

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,5 +1,5 @@
 import os
-from contextlib import contextmanager
+from typing import Generator
 from sqlmodel import SQLModel, create_engine, Session
 
 # Database URL is provided via environment variable in docker-compose
@@ -12,13 +12,10 @@ def init_db():
     """
     Initialize database by creating tables. Should be called on application startup.
     """
-    from .models import ConversationLog
+    from .models import ConversationLog  # noqa: F401
     SQLModel.metadata.create_all(engine)
 
-@contextmanager
-def get_session():
-    """
-    Context-managed session generator for dependency injection in FastAPI.
-    """
+def get_session() -> Generator[Session, None, None]:
+    """Yield a database session for FastAPI dependencies."""
     with Session(engine) as session:
         yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -92,6 +92,6 @@ def get_logs(session: Session = Depends(get_session)) -> List[ConversationLog]:
 @app.get("/risk_incidents")
 def get_risk_incidents(session: Session = Depends(get_session)) -> List[ConversationLog]:
     stmt = select(ConversationLog).where(
-        (ConversationLog.pii_detected == True) | (ConversationLog.risk_level == "high-risk")
+        ConversationLog.pii_detected | (ConversationLog.risk_level == "high-risk")
     )
     return session.exec(stmt).all()

--- a/backend/app/utils/risk_classifier.py
+++ b/backend/app/utils/risk_classifier.py
@@ -22,7 +22,7 @@ def _load_keywords() -> Dict[str, List[str]]:
     global _KEYWORDS_CACHE
     if _KEYWORDS_CACHE is not None:
         return _KEYWORDS_CACHE
-        default_path = Path(__file__).resolve().parent / "config" / "risk_keywords.yaml"
+    default_path = Path(__file__).resolve().parent / "config" / "risk_keywords.yaml"
     keywords_file = os.getenv("RISK_KEYWORDS_FILE", str(default_path))
     data: Dict[str, List[str]] = {}
     if yaml is not None and os.path.exists(keywords_file):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ PyYAML
 authlib
 jinja2
 python-multipart
+httpx

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Ensure the application package is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Set environment variables before importing application
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+os.environ.setdefault("LOGS_DIR", tempfile.mkdtemp())
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_health_endpoint():
+    with TestClient(app) as client:
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+
+def test_proxy_and_logs():
+    with TestClient(app) as client:
+        payload = {"messages": [{"role": "user", "content": "hello"}]}
+        response = client.post("/proxy", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "conversation_id" in data
+        assert data["reply"].startswith("Echo")
+
+        logs_response = client.get("/logs")
+        assert logs_response.status_code == 200
+        logs = logs_response.json()
+        assert isinstance(logs, list)
+        assert any(log["prompt"] == "hello" for log in logs)

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_DB: guardpilot
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
 
   backend:
     build: ../backend


### PR DESCRIPTION
## Summary
- fix risk keyword loader and session generator
- add package init and basic API tests
- resolve Ruff lint errors for ConversationLog queries
- expose Postgres port and add httpx dependency for local testing

## Testing
- `ruff check .`
- `pytest backend/tests/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e4e22a9c88326b0e9dab5b650915f