### PR TITLE
feat: filter conversation logs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from fastapi import FastAPI, Depends, HTTPException
 from sqlmodel import Session, select
-from typing import List, Optional
 import uuid
 import os
 import asyncio
@@ -20,8 +19,8 @@ class Message(BaseModel):
     content: str
 
 class LLMRequest(BaseModel):
-    conversation_id: Optional[str] = None
-    messages: List[Message]
+    conversation_id: str | None = None
+    messages: list[Message]
 
 class LLMResponse(BaseModel):
     conversation_id: str
@@ -87,16 +86,16 @@ async def proxy(request: LLMRequest, session: Session = Depends(get_session)) ->
 
 @app.get("/logs")
 def get_logs(
-    conversation_id: Optional[str] = None,
+    conversation_id: str | None = None,
     session: Session = Depends(get_session),
-) -> List[ConversationLog]:
+) -> list[ConversationLog]:
     stmt = select(ConversationLog)
     if conversation_id:
         stmt = stmt.where(ConversationLog.conversation_id == conversation_id)
     return session.exec(stmt).all()
 
 @app.get("/risk_incidents")
-def get_risk_incidents(session: Session = Depends(get_session)) -> List[ConversationLog]:
+def get_risk_incidents(session: Session = Depends(get_session)) -> list[ConversationLog]:
     stmt = select(ConversationLog).where(
         ConversationLog.pii_detected | (ConversationLog.risk_level == "high-risk")
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,8 +86,14 @@ async def proxy(request: LLMRequest, session: Session = Depends(get_session)) ->
     return LLMResponse(conversation_id=conv_id, reply=reply)
 
 @app.get("/logs")
-def get_logs(session: Session = Depends(get_session)) -> List[ConversationLog]:
-    return session.exec(select(ConversationLog)).all()
+def get_logs(
+    conversation_id: Optional[str] = None,
+    session: Session = Depends(get_session),
+) -> List[ConversationLog]:
+    stmt = select(ConversationLog)
+    if conversation_id:
+        stmt = stmt.where(ConversationLog.conversation_id == conversation_id)
+    return session.exec(stmt).all()
 
 @app.get("/risk_incidents")
 def get_risk_incidents(session: Session = Depends(get_session)) -> List[ConversationLog]:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -35,3 +35,22 @@ def test_proxy_and_logs():
         logs = logs_response.json()
         assert isinstance(logs, list)
         assert any(log["prompt"] == "hello" for log in logs)
+
+
+def test_logs_filter_by_conversation_id():
+    with TestClient(app) as client:
+        payload1 = {
+            "conversation_id": "conv-1",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        payload2 = {
+            "conversation_id": "conv-2",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        client.post("/proxy", json=payload1)
+        client.post("/proxy", json=payload2)
+        response = client.get("/logs", params={"conversation_id": "conv-1"})
+        assert response.status_code == 200
+        logs = response.json()
+        assert len(logs) == 1
+        assert logs[0]["conversation_id"] == "conv-1"

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -54,3 +54,15 @@ def test_logs_filter_by_conversation_id():
         logs = response.json()
         assert len(logs) == 1
         assert logs[0]["conversation_id"] == "conv-1"
+
+
+def test_logs_filter_with_unknown_conversation_id():
+    with TestClient(app) as client:
+        payload = {
+            "conversation_id": "conv-x",
+            "messages": [{"role": "user", "content": "hey"}],
+        }
+        client.post("/proxy", json=payload)
+        response = client.get("/logs", params={"conversation_id": "missing"})
+        assert response.status_code == 200
+        assert response.json() == []


### PR DESCRIPTION
## Summary
- allow querying conversation logs by `conversation_id`
- test `/logs` endpoint filtering

## Testing
- `cd backend && ruff check .`
- `cd backend && pytest -q`
- `cd backend && docker build -t guardpilot-backend .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `cd backend && trivy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68944d697e788326ad250c13602b1961