### PR TITLE
fix: configure backend url for chat

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -1,2 +1,48 @@
+import os
+
+import requests
 import streamlit as st
-st.title("GuardPilot UI placeholder")
+
+BACKEND_URL = os.environ.get("BACKEND_URL", "http://localhost:8000")
+
+st.title("GuardPilot Chat")
+
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+if "conversation_id" not in st.session_state:
+    st.session_state.conversation_id = None
+
+
+def send_message() -> None:
+    user_input = st.session_state.user_input.strip()
+    if not user_input:
+        return
+    st.session_state.messages.append({"role": "user", "content": user_input})
+    payload = {
+        "conversation_id": st.session_state.conversation_id,
+        "messages": st.session_state.messages,
+    }
+    try:
+        response = requests.post(
+            f"{BACKEND_URL}/proxy", json=payload, timeout=30
+        )
+        response.raise_for_status()
+        data = response.json()
+        st.session_state.conversation_id = data.get("conversation_id")
+        st.session_state.messages.append(
+            {"role": "assistant", "content": data.get("reply", "")}
+        )
+    except Exception as exc:
+        st.session_state.messages.append(
+            {"role": "assistant", "content": f"Error: {exc}"}
+        )
+    st.session_state.user_input = ""
+
+
+for msg in st.session_state.messages:
+    with st.chat_message(msg["role"]):
+        st.markdown(msg["content"])
+
+st.text_input("Message", key="user_input")
+st.button("Send", on_click=send_message)
+

--- a/ui/app.py
+++ b/ui/app.py
@@ -14,6 +14,7 @@ if "conversation_id" not in st.session_state:
 
 
 def send_message() -> None:
+    """Send the user's prompt to the backend and store the reply."""
     user_input = st.session_state.user_input.strip()
     if not user_input:
         return

--- a/ui/app.py
+++ b/ui/app.py
@@ -3,6 +3,7 @@ import os
 import requests
 import streamlit as st
 
+# Base URL for the FastAPI backend; override with BACKEND_URL env var.
 BACKEND_URL = os.environ.get("BACKEND_URL", "http://localhost:8000")
 
 st.title("GuardPilot Chat")


### PR DESCRIPTION
## Summary
- use BACKEND_URL to call FastAPI `/proxy`
- simplify send flow in Streamlit chat

## Testing
- `ruff check .`
- `pytest`
- `docker build -t guardpilot-ui ui` *(fails: command not found)*
- `trivy fs .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68973e00628483268f5d5601d57e49a1