### PR TITLE
feat(ui): add chat helpers and i18n

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,14 @@
+{
+  "title": "GuardPilot Chat",
+  "model": "Model",
+  "max_tokens": "Max tokens",
+  "language": "Language",
+  "message": "Message",
+  "send": "Send",
+  "clear_chat": "Clear chat",
+  "error_timeout": "Request timed out",
+  "error_server": "Server error",
+  "error_client": "Client error",
+  "error_validation": "Validation error",
+  "message_too_long": "Message too long"
+}

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -1,0 +1,14 @@
+{
+  "title": "GuardPilot Czat",
+  "model": "Model",
+  "max_tokens": "Maks tokenów",
+  "language": "Język",
+  "message": "Wiadomość",
+  "send": "Wyślij",
+  "clear_chat": "Wyczyść czat",
+  "error_timeout": "Przekroczono czas oczekiwania",
+  "error_server": "Błąd serwera",
+  "error_client": "Błąd klienta",
+  "error_validation": "Błąd walidacji",
+  "message_too_long": "Wiadomość zbyt długa"
+}

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,42 +1,91 @@
-import requests
-import streamlit as st
+import html
+import uuid
+from datetime import datetime
 
-st.title("GuardPilot Chat")
+import streamlit as st
+from requests import HTTPError, Timeout
+
+from helpers import get_config, send_chat, trim_history, t
+
+cfg = get_config()
 
 if "messages" not in st.session_state:
     st.session_state.messages = []
-if "conversation_id" not in st.session_state:
-    st.session_state.conversation_id = None
+if "lang" not in st.session_state:
+    st.session_state.lang = "en"
+
+st.title(t("title", st.session_state.lang))
+
+
+with st.sidebar:
+    st.session_state.model = st.selectbox(
+        t("model", st.session_state.lang), [cfg["default_model"]]
+    )
+    st.session_state.max_tokens = st.number_input(
+        t("max_tokens", st.session_state.lang),
+        min_value=1,
+        max_value=4000,
+        value=cfg["max_tokens"],
+    )
+    st.session_state.lang = st.selectbox(
+        t("language", st.session_state.lang),
+        ["en", "pl"],
+        index=["en", "pl"].index(st.session_state.lang),
+    )
+
+
+def add_message(role: str, content: str) -> None:
+    st.session_state.messages.append(
+        {
+            "role": role,
+            "content": content,
+            "ts": datetime.utcnow().isoformat(),
+            "id": str(uuid.uuid4()),
+        }
+    )
 
 
 def send_message() -> None:
-    user_input = st.session_state.user_input.strip()
-    if not user_input:
+    content = st.session_state.user_input.strip()
+    if not content:
         return
-    st.session_state.messages.append({"role": "user", "content": user_input})
-    payload = {
-        "conversation_id": st.session_state.conversation_id,
-        "messages": st.session_state.messages,
-    }
+    if len(content) > 8000:
+        st.error(t("message_too_long", st.session_state.lang))
+        return
+    add_message("user", content)
+    history = trim_history(st.session_state.messages, cfg["history_max_turns"])
     try:
-        response = requests.post("/proxy", json=payload, timeout=30)
-        response.raise_for_status()
-        data = response.json()
-        st.session_state.conversation_id = data.get("conversation_id")
-        st.session_state.messages.append(
-            {"role": "assistant", "content": data.get("reply", "")}
+        data = send_chat(
+            history,
+            st.session_state.model,
+            st.session_state.max_tokens,
+            cfg["api_base"],
         )
-    except Exception as exc:
-        st.session_state.messages.append(
-            {"role": "assistant", "content": f"Error: {exc}"}
-        )
+    except Timeout:
+        st.error(t("error_timeout", st.session_state.lang))
+        return
+    except HTTPError as exc:
+        status = exc.response.status_code
+        if status == 422:
+            st.error(t("error_validation", st.session_state.lang))
+        elif 400 <= status < 500:
+            st.error(t("error_client", st.session_state.lang))
+        else:
+            st.error(t("error_server", st.session_state.lang))
+        return
+    add_message("assistant", data.get("reply", ""))
     st.session_state.user_input = ""
-    st.experimental_rerun()
+
+
+def clear_chat() -> None:
+    st.session_state.messages = []
 
 
 for msg in st.session_state.messages:
     with st.chat_message(msg["role"]):
-        st.markdown(msg["content"])
+        st.markdown(html.escape(msg["content"]))
 
-st.text_input("Message", key="user_input")
-st.button("Send", on_click=send_message)
+st.text_input(t("message", st.session_state.lang), key="user_input")
+col1, col2 = st.columns(2)
+col1.button(t("send", st.session_state.lang), on_click=send_message)
+col2.button(t("clear_chat", st.session_state.lang), on_click=clear_chat)

--- a/ui/helpers.py
+++ b/ui/helpers.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+import requests
+
+BASE_PATH = Path(__file__).resolve().parent.parent
+_TRANSLATIONS: dict[str, dict[str, str]] | None = None
+
+
+def get_config() -> Dict[str, Any]:
+    return {
+        "api_base": os.getenv("GP_API_BASE", "http://127.0.0.1:8000"),
+        "default_model": os.getenv("DEFAULT_MODEL", "gpt-3.5-turbo-0125"),
+        "max_tokens": int(os.getenv("MAX_TOKENS", "256")),
+        "history_max_turns": int(os.getenv("HISTORY_MAX_TURNS", "10")),
+    }
+
+
+def trim_history(
+    messages: List[Dict[str, Any]], limit_turns: int
+) -> List[Dict[str, Any]]:
+    return messages[-limit_turns * 2 :]
+
+
+def shape_payload(
+    messages: List[Dict[str, Any]], model: str, max_tokens: int
+) -> Dict[str, Any]:
+    return {
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": [{"role": m["role"], "content": m["content"]} for m in messages],
+    }
+
+
+def load_translations() -> Dict[str, Dict[str, str]]:
+    global _TRANSLATIONS
+    if _TRANSLATIONS is None:
+        _TRANSLATIONS = {}
+        for lang in ("en", "pl"):
+            path = BASE_PATH / "i18n" / f"{lang}.json"
+            with path.open(encoding="utf-8") as f:
+                _TRANSLATIONS[lang] = json.load(f)
+    return _TRANSLATIONS
+
+
+def t(key: str, lang: str) -> str:
+    translations = load_translations()
+    return translations.get(lang, {}).get(key, translations["en"].get(key, key))
+
+
+def send_chat(
+    messages: List[Dict[str, Any]],
+    model: str,
+    max_tokens: int,
+    api_base: str,
+    streaming: bool = False,
+) -> Dict[str, Any]:
+    payload = shape_payload(messages, model, max_tokens)
+    resp = requests.post(f"{api_base}/proxy", json=payload, timeout=30)
+    resp.raise_for_status()
+    return resp.json()

--- a/ui/tests/test_ui_helpers.py
+++ b/ui/tests/test_ui_helpers.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import helpers
+
+
+def test_trim_history():
+    messages = [
+        {"role": "user", "content": "1"},
+        {"role": "assistant", "content": "a"},
+        {"role": "user", "content": "2"},
+        {"role": "assistant", "content": "b"},
+    ]
+    assert helpers.trim_history(messages, 1) == [
+        {"role": "user", "content": "2"},
+        {"role": "assistant", "content": "b"},
+    ]
+
+
+def test_shape_payload():
+    messages = [
+        {"role": "user", "content": "hi", "ts": "1", "id": "a"},
+        {"role": "assistant", "content": "hello", "ts": "2", "id": "b"},
+    ]
+    payload = helpers.shape_payload(messages, "gpt", 256)
+    assert payload == {
+        "model": "gpt",
+        "max_tokens": 256,
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ],
+    }
+
+
+def test_i18n_lookup():
+    assert helpers.t("send", "pl") == "Wyślij"
+
+
+def test_i18n_fallback(monkeypatch):
+    translations = {"en": {"greet": "Hello"}, "pl": {}}
+    monkeypatch.setattr(helpers, "_TRANSLATIONS", translations)
+    assert helpers.t("greet", "pl") == "Hello"


### PR DESCRIPTION
## Summary
- build reusable UI helpers for config, history trim, payload shaping and API calls
- internationalize UI with EN/PL strings and translation helper
- redesign Streamlit chat with sidebar settings, error banners and history cap

## Testing
- `ruff check ui/app.py ui/helpers.py ui/tests/test_ui_helpers.py`
- `black --check ui/app.py ui/helpers.py ui/tests/test_ui_helpers.py`
- `rm -f test.db && pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f99a3325c832692ab395b63fa130d